### PR TITLE
Adding support for Windows

### DIFF
--- a/Tailwind/Commands/InstallCommand.php
+++ b/Tailwind/Commands/InstallCommand.php
@@ -49,7 +49,10 @@ class InstallCommand extends Command
 
         $this->copyFiles();
 
-        $this->runCommands();
+        if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN')
+            $this->runCommands();
+        else
+            $this->outputWindowsInstructions();
     }
 
     private function copyFiles()
@@ -162,5 +165,13 @@ class InstallCommand extends Command
                 str_replace('my-theme', Config::get('theming.theme'), File::get($srcPath))
             );
         }
+    }
+
+    private function outputWindowsInstructions()
+    {
+        $this->info('You are on a Windows system. Please do the follwing commands within your theme directory manually: ');
+        $this->info('    yarn install');
+        $this->info('Within node_modules/.bin:');
+        $this->info('    tailwind.cmd init ../../tailwind.js');
     }
 }

--- a/Tailwind/resources/assets/js/webpack.mix.js
+++ b/Tailwind/resources/assets/js/webpack.mix.js
@@ -14,6 +14,7 @@ mix.postCss('css/base.css', 'css/my-theme.css')
     ], 'js/my-theme.js');
 
 mix.disableSuccessNotifications();
+mix.setPublicPath('/');
 
 if (mix.inProduction()) {
     mix.purgeCss({

--- a/Tailwind/resources/assets/package.json
+++ b/Tailwind/resources/assets/package.json
@@ -1,10 +1,10 @@
 {
     "private": true,
     "scripts": {
-        "dev": "NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "watch": "NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "hot": "NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "production": "NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+        "dev": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "watch": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --watch --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+        "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
         "cross-env": "^5.1.3",


### PR DESCRIPTION
Fixed an issue when running on Windows that caused the command to throw an error.

- Updated "package.json" to work on Windows
- Updated "webpack.mix.js" to prevent yarn watch to get stuck at 95%
- Added instructions for Windows users in "InstallCommand.php"