### PR TITLE
Update base.css

### DIFF
--- a/Tailwind/resources/assets/css/base.css
+++ b/Tailwind/resources/assets/css/base.css
@@ -9,7 +9,7 @@
  *
  * @import «tailwindcss/preflight»;
  */
-@tailwind preflight;
+@tailwind base;
 
 /**
  * This injects any component classes registered by plugins.


### PR DESCRIPTION
ERROR in ./node_modules/css-loader??ref--5-2!./node_modules/postcss-loader/lib??postcss!./css/base.css
Module build failed: Syntax Error 

(12:11) `@tailwind preflight` is not a valid at-rule in Tailwind v1.0, use `@tailwind base` instead.

  10 |  * @import «tailwindcss/preflight»;
  11 |  */
> 12 | @tailwind preflight;
     |           ^
  13 | 
  14 | /**

 @ ./css/base.css 4:14-136
 @ multi ./js/base.js ./css/base.css